### PR TITLE
NP-2512 Add a deployment for pulsar-manager

### DIFF
--- a/test/pulsar-manager/README.md
+++ b/test/pulsar-manager/README.md
@@ -1,0 +1,21 @@
+# Using pulsar manager
+
+
+1. To install the manager, create the `pulsar-manager.*.yaml` files on the target cluster
+
+```
+$ kubectl -nnalej create -f pulsar-manager.deployment.yaml
+$ kubectl -nnalej create -f pulsar-manager.service.yaml
+```
+
+2. Forward the port to the UI
+
+```
+$ kubectl -nnalej port-forward service/pulsar-manager 9527:9527
+```
+
+3. Connect to http://localhost:9527 using pulsar:pulsar
+
+4. Create a new environment targeting http://broker.nalej:8080
+
+5. Enjoy

--- a/test/pulsar-manager/pulsar-manager.deployment.yaml
+++ b/test/pulsar-manager/pulsar-manager.deployment.yaml
@@ -1,0 +1,52 @@
+###
+# Pulsar Manager
+###
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    cluster: management
+    component: pulsar
+  name: pulsar-manager
+  namespace: nalej
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      cluster: management
+      component: pulsar
+  template:
+    metadata:
+      labels:
+        cluster: management
+        component: pulsar
+    spec:
+      containers:
+        - name: pulsar-manager
+          image: apachepulsar/pulsar-manager:v0.1.0
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: manager-data
+              mountPath: "/data"
+          env:
+          - name: DRIVER_CLASS_NAME
+            value: "org.postgresql.Driver"
+          - name: URL
+            value: "jdbc:postgresql://127.0.0.1:5432/pulsar_manager"
+          - name: USERNAME
+            value: "pulsar"
+          - name: PASSWORD
+            value: "pulsar"
+          - name: LOG_LEVEL
+            value: "DEBUG"
+          - name: REDIRECT_PORT
+            value: "9527"
+          - name: REDIRECT_HOST
+            value: "http://pulsar-manager.nalej"
+          securityContext:
+            runAsUser: 0
+      volumes:
+        - name: manager-data
+          emptyDir: {}

--- a/test/pulsar-manager/pulsar-manager.service.yaml
+++ b/test/pulsar-manager/pulsar-manager.service.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: pulsar-manager
+  labels:
+    cluster: management
+    compoment: pulsar
+  namespace: nalej
+spec:
+  selector:
+    cluster: management
+    component: pulsar
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 9527
+    targetPort: 9527


### PR DESCRIPTION
#### What does this PR do?

* Adds a kubernetes deployment to launch [pulsar-manager](https://github.com/apache/pulsar-manager) in the `nalej` namespace of the management cluster.

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

Follow the instructions on the readme file.

#### Any background context you want to provide?

The associated bug requires further debugging and understanding of what could be happening inside pulsar. For that purpose this type of tooling may provide insights when deploying it in a cluster that exhibits the issue.

#### What are the relevant tickets?

- [NP-2512](https://nalej.atlassian.net/browse/NP-2512)

#### Screenshots (if appropriate)

#### Questions
